### PR TITLE
Switch to musl build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,9 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
+    - name: Check ldd version
+      run: ldd --version
+
     - name: Build binary
       uses: houseabsolute/actions-rust-cross@v1
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - target: x86_64-unknown-linux-gnu
+          - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
             name: php-fpm-queue-monitor-linux-amd64
-          - target: aarch64-unknown-linux-gnu
+          - target: aarch64-unknown-linux-musl
             os: ubuntu-latest
             name: php-fpm-queue-monitor-linux-arm64
 


### PR DESCRIPTION
We don't have a stable known version of LibC to link against, so let's do with musl to make things simpler.